### PR TITLE
Agrega ruta de plantillas PDF personalizadas + Envia los parametros adicionales del PDF por POST

### DIFF
--- a/.env
+++ b/.env
@@ -26,6 +26,7 @@ CORS_ALLOW_ORIGIN=.
 
 ###> greenter/greenter ###
 WKHTMLTOPDF_PATH=wkhtmltopdf
+TEMPLATESPDF_PATH=/path/to/template
 CLIENT_TOKEN=123456
 SOL_USER=20000000001MODDATOS
 SOL_PASS=moddatos

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -51,7 +51,7 @@ services:
 
     Greenter\Report\HtmlReport:
         arguments:
-            - ''
+            - '%env(TEMPLATESPDF_PATH)%'
             - cache: '%kernel.cache_dir%'
               strict_variables: true
 

--- a/src/Service/DocumentRequest.php
+++ b/src/Service/DocumentRequest.php
@@ -122,7 +122,7 @@ class DocumentRequest implements DocumentRequestInterface
      */
     public function pdf(): Response
     {
-        $document = $this->getDocument("document");
+        $document = $this->getDocument();
         $parameters = $this->getKeyContent("parameters");
 
         /**@var $errors array */
@@ -131,16 +131,16 @@ class DocumentRequest implements DocumentRequestInterface
 //            return $this->json($errors, 400);
 //        }
 
-        $jsonCompanies = $this->getParameter('companies');
-
-        $ruc = $document->getCompany()->getRuc();
-        if (empty($companies) && ($companies = json_decode($jsonCompanies, true)) && array_key_exists($ruc, $companies)) {
-            $logo = $this->getFile($companies[$ruc]['logo']);
-        } else {
-            $logo = $this->getParameter('logo');
-        }
 
         if(!$parameters) {
+            $jsonCompanies = $this->getParameter('companies');
+            $ruc = $document->getCompany()->getRuc();
+            if (empty($companies) && ($companies = json_decode($jsonCompanies, true)) && array_key_exists($ruc, $companies)) {
+                $logo = $this->getFile($companies[$ruc]['logo']);
+            } else {
+                $logo = $this->getParameter('logo');
+            }
+
             $parameters = [
                 'system' => [
                     'logo' => $logo,
@@ -174,11 +174,11 @@ class DocumentRequest implements DocumentRequestInterface
     /**
      * @return DocumentInterface
      */
-    private function getDocument(string $key = ''): DocumentInterface
+    private function getDocument(): DocumentInterface
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        return $this->parser->getObject($request, $this->className, $key);
+        return $this->parser->getObject($request, $this->className);
     }
 
     /**

--- a/src/Service/DocumentRequest.php
+++ b/src/Service/DocumentRequest.php
@@ -122,7 +122,8 @@ class DocumentRequest implements DocumentRequestInterface
      */
     public function pdf(): Response
     {
-        $document = $this->getDocument();
+        $document = $this->getDocument("document");
+        $parameters = $this->getKeyContent("parameters");
 
         /**@var $errors array */
 //        $errors = $this->validator->validate($document);
@@ -139,15 +140,17 @@ class DocumentRequest implements DocumentRequestInterface
             $logo = $this->getParameter('logo');
         }
 
-        $parameters = [
-            'system' => [
-                'logo' => $logo,
-//                'hash' => '',
-            ],
-            'user' => [
-                'header' => '',
-            ]
-        ];
+        if(!$parameters) {
+            $parameters = [
+                'system' => [
+                    'logo' => $logo,
+    //                'hash' => '',
+                ],
+                'user' => [
+                    'header' => '',
+                ]
+            ];
+        }
 
         $report = $this->getReport();
         $pdf = $report->render($document, $parameters);
@@ -171,11 +174,21 @@ class DocumentRequest implements DocumentRequestInterface
     /**
      * @return DocumentInterface
      */
-    private function getDocument(): DocumentInterface
+    private function getDocument(string $key = ''): DocumentInterface
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        return $this->parser->getObject($request, $this->className);
+        return $this->parser->getObject($request, $this->className, $key);
+    }
+
+    /**
+     * @return Array
+     */
+    private function getKeyContent(string $key): ?Array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        return $this->parser->getKey($request, $key);
     }
 
     private function getReport(): ReportInterface

--- a/src/Service/DocumentRequestParser.php
+++ b/src/Service/DocumentRequestParser.php
@@ -31,16 +31,40 @@ class DocumentRequestParser implements RequestParserInterface
     /**
      * @param Request $request
      * @param string $class
+     * @param string $key
      * @return mixed
      */
-    function getObject(Request $request, string $class): DocumentInterface
+    function getObject(Request $request, string $class, string $key = ''): DocumentInterface
     {
         $data = $request->getContent();
+
+        if(!empty($key)) {
+            $dataJson = json_decode($data, true);
+            if(array_key_exists($key, $dataJson)) {
+                return $this->serializer->deserialize(
+                    json_encode($dataJson[$key]),
+                    $class,
+                    'json'
+                );
+            }
+        }
 
         return $this->serializer->deserialize(
             $data,
             $class,
             'json'
         );
+    }
+
+    /**
+     * @param Request $request
+     * @param string $key
+     * @return Array
+     */
+    function getKey(Request $request, string $key): ?Array
+    {
+        $data = json_decode($request->getContent(), true);
+
+        return array_key_exists($key, $data) ? $data[$key] : null;
     }
 }

--- a/src/Service/DocumentRequestParser.php
+++ b/src/Service/DocumentRequestParser.php
@@ -31,22 +31,19 @@ class DocumentRequestParser implements RequestParserInterface
     /**
      * @param Request $request
      * @param string $class
-     * @param string $key
      * @return mixed
      */
-    function getObject(Request $request, string $class, string $key = ''): DocumentInterface
+    function getObject(Request $request, string $class): DocumentInterface
     {
         $data = $request->getContent();
 
-        if(!empty($key)) {
-            $dataJson = json_decode($data, true);
-            if(array_key_exists($key, $dataJson)) {
-                return $this->serializer->deserialize(
-                    json_encode($dataJson[$key]),
-                    $class,
-                    'json'
-                );
-            }
+        $dataJson = json_decode($data, true);
+        if(array_key_exists('document', $dataJson)) {
+            return $this->serializer->deserialize(
+                json_encode($dataJson['document']),
+                $class,
+                'json'
+            );
         }
 
         return $this->serializer->deserialize(
@@ -59,7 +56,7 @@ class DocumentRequestParser implements RequestParserInterface
     /**
      * @param Request $request
      * @param string $key
-     * @return Array
+     * @return mixed
      */
     function getKey(Request $request, string $key): ?Array
     {

--- a/src/Service/RequestParserInterface.php
+++ b/src/Service/RequestParserInterface.php
@@ -18,7 +18,15 @@ interface RequestParserInterface
     /**
      * @param Request $request
      * @param string $class
+     * @param string $key
      * @return mixed
      */
-    function getObject(Request $request, string $class);
+    function getObject(Request $request, string $class, string $key);
+
+    /**
+     * @param Request $request
+     * @param string $key
+     * @return array
+     */
+    function getKey(Request $request, string $key);
 }

--- a/src/Service/RequestParserInterface.php
+++ b/src/Service/RequestParserInterface.php
@@ -18,15 +18,14 @@ interface RequestParserInterface
     /**
      * @param Request $request
      * @param string $class
-     * @param string $key
      * @return mixed
      */
-    function getObject(Request $request, string $class, string $key);
+    function getObject(Request $request, string $class);
 
     /**
      * @param Request $request
      * @param string $key
-     * @return array
+     * @return mixed
      */
     function getKey(Request $request, string $key);
 }


### PR DESCRIPTION
Se modifico lo siguiente:

**lycet/.env**

`TEMPLATESPDF_PATH=/path/to/template # Agregar la ruta estatica de las plantillas PDF`

**lycet//config/services.yaml**

```
    Greenter\Report\HtmlReport:
        arguments:
            - '%env(TEMPLATESPDF_PATH)%' # Ruta donde se encuentra las plantillas PDF tomado del .env
            - cache: '%kernel.cache_dir%' # Colocar en false mientras se modifican las plantillas
              strict_variables: true
```

Se incluyo la funcionalidad para que se pueda enviar a la ruta **invoice/pdf?token=123456** tanto el **documento** como los **parametros** del PDF

```
{
    "parameters": {
        "system": {"logo": "base64"}, 
        "user": {"header": ""}
    },
    "document":   {
        "ublVersion": "2.1",
        "tipoOperacion": "0101",
        ...
```