### PR TITLE
Add status endpoint for retrieving CDR status

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -130,5 +130,12 @@ services:
     App\EventSubscriber\TokenSubscriber:
         arguments:
             $token: '%token%'
+
+    App\Controller\v1\InvoiceController:
+        arguments:
+            - '@App\Service\DocumentRequestInterface'
+            - '@App\Service\EnvConfigProvider'
+            - '@App\Service\ConfigProviderInterface'
+            - '@JMS\Serializer\SerializerInterface'
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Controller/v1/InvoiceController.php
+++ b/src/Controller/v1/InvoiceController.php
@@ -8,9 +8,19 @@
 
 namespace App\Controller\v1;
 
+use App\Service\ConfigProviderInterface;
 use App\Service\DocumentRequestInterface;
+use App\Service\EnvConfigProvider;
+use App\Service\FileConfigProvider;
+use App\Service\SeeFactory;
 use Greenter\Model\Sale\Invoice;
+use Greenter\Ws\Services\ConsultCdrService;
+use Greenter\Ws\Services\SoapClient;
+use Greenter\Ws\Services\SunatEndpoints;
+use JMS\Serializer\SerializerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -27,13 +37,34 @@ class InvoiceController extends AbstractController
     private $document;
 
     /**
+     * @var ConfigProviderInterface
+     */
+    private $config;
+
+    /**
+     * @var ConfigProviderInterface
+     */
+    private $fileProvider;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
      * InvoiceController constructor.
      * @param DocumentRequestInterface $document
+     * @param EnvConfigProvider $config
+     * @param FileConfigProvider $fileProvider
+     * @param SerializerInterface $serializer
      */
-    public function __construct(DocumentRequestInterface $document)
+    public function __construct(DocumentRequestInterface $document, EnvConfigProvider $config, FileConfigProvider $fileProvider, SerializerInterface $serializer)
     {
         $this->document = $document;
         $this->document->setDocumentType(Invoice::class);
+        $this->config = $config;
+        $this->fileProvider = $fileProvider;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -64,5 +95,81 @@ class InvoiceController extends AbstractController
     public function pdf(): Response
     {
         return $this->document->pdf();
+    }
+
+    /**
+     * @Route("/status", methods={"GET"})
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function status(Request $request): JsonResponse
+    {
+        $tipo = $request->query->get('tipo');
+        $serie = $request->query->get('serie');
+        $numero = $request->query->get('numero');
+        if (empty($tipo)) {
+            return new JsonResponse(['message' => 'Tipo Requerido'], 400);
+        }
+        if (empty($serie)) {
+            return new JsonResponse(['message' => 'Serie Requerido'], 400);
+        }
+        if (empty($numero)) {
+            return new JsonResponse(['message' => 'Numero Requerido'], 400);
+        }
+        $see = $this->getCdrStatusService($request->query->get('ruc'));
+        $username = $this->getConfig('SOL_USER', $request->query->get('ruc'));
+        $ruc = substr($username, 0, 11);
+        $result = $see->getStatusCdr($ruc, $tipo, $serie, $numero);
+
+        if ($result->isSuccess()) {
+            $result->setCdrZip(base64_encode($result->getCdrZip()));
+        }
+
+        $json = $this->serializer->serialize($result, 'json');
+
+        return new JsonResponse($json, 200, [], true);
+    }
+
+    /**
+     * @param $ruc |null
+     * @return ConsultCdrService|false
+     */
+    private function getCdrStatusService($ruc = null)
+    {
+        $ws = new SoapClient(SunatEndpoints::FE_CONSULTA_CDR . '?wsdl');
+
+        if (!empty($ruc)) {
+            $ws->setCredentials($this->getConfig('SOL_USER', $ruc), $this->getConfig('SOL_PASS', $ruc));
+        } else {
+            $ws->setCredentials($this->getConfig('SOL_USER'), $this->getConfig('SOL_PASS'));
+        }
+
+        $service = new ConsultCdrService();
+        $service->setClient($ws);
+
+        return $service;
+    }
+
+    private function getConfig($key, $ruc = null)
+    {
+        if (empty($ruc)) {
+            return $this->config->get($key);
+        }
+
+        $jsonCompanies = $this->fileProvider->get('companies');
+        if (empty($jsonCompanies)) {
+            return false;
+        }
+
+        $companies = json_decode($jsonCompanies, true);
+
+        if (!array_key_exists($ruc, $companies)) {
+            return false;
+        }
+
+        $config = $companies[$ruc];
+
+        return $config[$key];
     }
 }

--- a/src/Controller/v1/InvoiceController.php
+++ b/src/Controller/v1/InvoiceController.php
@@ -10,9 +10,6 @@ namespace App\Controller\v1;
 
 use App\Service\ConfigProviderInterface;
 use App\Service\DocumentRequestInterface;
-use App\Service\EnvConfigProvider;
-use App\Service\FileConfigProvider;
-use App\Service\SeeFactory;
 use Greenter\Model\Sale\Invoice;
 use Greenter\Ws\Services\ConsultCdrService;
 use Greenter\Ws\Services\SoapClient;
@@ -54,11 +51,11 @@ class InvoiceController extends AbstractController
     /**
      * InvoiceController constructor.
      * @param DocumentRequestInterface $document
-     * @param EnvConfigProvider $config
-     * @param FileConfigProvider $fileProvider
+     * @param ConfigProviderInterface $config
+     * @param ConfigProviderInterface $fileProvider
      * @param SerializerInterface $serializer
      */
-    public function __construct(DocumentRequestInterface $document, EnvConfigProvider $config, FileConfigProvider $fileProvider, SerializerInterface $serializer)
+    public function __construct(DocumentRequestInterface $document, ConfigProviderInterface $config, ConfigProviderInterface $fileProvider, SerializerInterface $serializer)
     {
         $this->document = $document;
         $this->document->setDocumentType(Invoice::class);


### PR DESCRIPTION
## Descripción del cambio

Se agrega un nuevo endpoint `/status` con el método HTTP GET para obtener el estado de un CDR (Comprobante de Recepción). El endpoint utiliza los parámetros de consulta 'tipo', 'serie' y 'numero' para identificar el CDR. Si falta alguno de estos parámetros, el endpoint devuelve una respuesta de error correspondiente.

El método 'status' en el controlador utiliza el método 'getCdrStatusService' para obtener una instancia de ConsultCdrService y luego obtiene el estado del CDR utilizando los valores de 'tipo', 'serie' y 'numero' proporcionados. Si el resultado es exitoso, el CDR se codifica en base64 y se devuelve en la respuesta JSON.

El método 'getCdrStatusService' inicializa un SoapClient y establece las credenciales en función del 'ruc' proporcionado. El método 'getConfig' se utiliza para obtener los valores de configuración, incluidos SOL_USER y SOL_PASS, tanto de la configuración general como de las configuraciones específicas de la empresa.

Estos cambios mejoran la funcionalidad de la aplicación al permitir a los usuarios obtener el estado de un CDR utilizando el nuevo endpoint '/status'.

