### PR TITLE
fix: make DocumentRequest stateless to prevent cross-request state bugs

### DIFF
--- a/src/Controller/v1/DespatchController.php
+++ b/src/Controller/v1/DespatchController.php
@@ -35,7 +35,6 @@ class DespatchController extends AbstractController
     public function __construct(DocumentRequestInterface $document, SerializerInterface $serializer)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Despatch::class);
         $this->serializer = $serializer;
     }
 
@@ -46,7 +45,8 @@ class DespatchController extends AbstractController
      */
     public function send(SeeApiFactory $factory): Response
     {
-        $document = $this->document->getDocument();
+        /** @var \Greenter\Model\Despatch\Despatch $document */
+        $document = $this->document->getDocument(Despatch::class);
         $see = $factory->build($document->getCompany()->getRuc());
         $result = $see->send($document);
 
@@ -69,7 +69,7 @@ class DespatchController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Despatch::class);
     }
 
     /**
@@ -79,7 +79,7 @@ class DespatchController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Despatch::class);
     }
 
     /**

--- a/src/Controller/v1/InvoiceController.php
+++ b/src/Controller/v1/InvoiceController.php
@@ -58,7 +58,6 @@ class InvoiceController extends AbstractController
     public function __construct(DocumentRequestInterface $document, ConfigProviderInterface $config, ConfigProviderInterface $fileProvider, SerializerInterface $serializer)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Invoice::class);
         $this->config = $config;
         $this->fileProvider = $fileProvider;
         $this->serializer = $serializer;
@@ -71,7 +70,7 @@ class InvoiceController extends AbstractController
      */
     public function send(): Response
     {
-        return $this->document->send();
+        return $this->document->send(Invoice::class);
     }
 
     /**
@@ -81,7 +80,7 @@ class InvoiceController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Invoice::class);
     }
 
     /**
@@ -91,7 +90,7 @@ class InvoiceController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Invoice::class);
     }
 
     /**

--- a/src/Controller/v1/NoteController.php
+++ b/src/Controller/v1/NoteController.php
@@ -33,7 +33,6 @@ class NoteController extends AbstractController
     public function __construct(DocumentRequestInterface $document)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Note::class);
     }
 
     /**
@@ -43,7 +42,7 @@ class NoteController extends AbstractController
      */
     public function send(): Response
     {
-        return $this->document->send();
+        return $this->document->send(Note::class);
     }
 
     /**
@@ -53,7 +52,7 @@ class NoteController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Note::class);
     }
 
     /**
@@ -63,6 +62,6 @@ class NoteController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Note::class);
     }
 }

--- a/src/Controller/v1/PerceptionController.php
+++ b/src/Controller/v1/PerceptionController.php
@@ -33,7 +33,6 @@ class PerceptionController extends AbstractController
     public function __construct(DocumentRequestInterface $document)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Perception::class);
     }
 
     /**
@@ -43,7 +42,7 @@ class PerceptionController extends AbstractController
      */
     public function send(): Response
     {
-        return $this->document->send();
+        return $this->document->send(Perception::class);
     }
 
     /**
@@ -53,7 +52,7 @@ class PerceptionController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Perception::class);
     }
 
     /**
@@ -63,6 +62,6 @@ class PerceptionController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Perception::class);
     }
 }

--- a/src/Controller/v1/RetentionController.php
+++ b/src/Controller/v1/RetentionController.php
@@ -33,7 +33,6 @@ class RetentionController extends AbstractController
     public function __construct(DocumentRequestInterface $document)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Retention::class);
     }
 
     /**
@@ -43,7 +42,7 @@ class RetentionController extends AbstractController
      */
     public function send(): Response
     {
-        return $this->document->send();
+        return $this->document->send(Retention::class);
     }
 
     /**
@@ -53,7 +52,7 @@ class RetentionController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Retention::class);
     }
 
     /**
@@ -63,6 +62,6 @@ class RetentionController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Retention::class);
     }
 }

--- a/src/Controller/v1/ReversionController.php
+++ b/src/Controller/v1/ReversionController.php
@@ -42,7 +42,6 @@ class ReversionController extends AbstractController
     public function __construct(DocumentRequestInterface $document, SerializerInterface $serializer)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Reversion::class);
         $this->serializer = $serializer;
     }
 
@@ -53,7 +52,7 @@ class ReversionController extends AbstractController
      */
     public function send(): Response
     {
-        return $this->document->send();
+        return $this->document->send(Reversion::class);
     }
 
     /**
@@ -63,7 +62,7 @@ class ReversionController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Reversion::class);
     }
 
     /**
@@ -73,7 +72,7 @@ class ReversionController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Reversion::class);
     }
 
     /**

--- a/src/Controller/v1/SummaryController.php
+++ b/src/Controller/v1/SummaryController.php
@@ -42,7 +42,6 @@ class SummaryController extends AbstractController
     public function __construct(DocumentRequestInterface $document, SerializerInterface $serializer)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Summary::class);
         $this->serializer = $serializer;
     }
 
@@ -53,7 +52,7 @@ class SummaryController extends AbstractController
      */
     public function send(): Response
     {
-        return $this->document->send();
+        return $this->document->send(Summary::class);
     }
 
     /**
@@ -63,7 +62,7 @@ class SummaryController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Summary::class);
     }
 
     /**
@@ -73,7 +72,7 @@ class SummaryController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Summary::class);
     }
 
     /**

--- a/src/Controller/v1/VoidedController.php
+++ b/src/Controller/v1/VoidedController.php
@@ -42,7 +42,6 @@ class VoidedController extends AbstractController
     public function __construct(DocumentRequestInterface $document, SerializerInterface $serializer)
     {
         $this->document = $document;
-        $this->document->setDocumentType(Voided::class);
         $this->serializer = $serializer;
     }
 
@@ -53,7 +52,7 @@ class VoidedController extends AbstractController
      */
     public function send(): Response
     {
-        return $this->document->send();
+        return $this->document->send(Voided::class);
     }
 
     /**
@@ -63,7 +62,7 @@ class VoidedController extends AbstractController
      */
     public function xml(): Response
     {
-        return $this->document->xml();
+        return $this->document->xml(Voided::class);
     }
 
     /**
@@ -73,7 +72,7 @@ class VoidedController extends AbstractController
      */
     public function pdf(): Response
     {
-        return $this->document->pdf();
+        return $this->document->pdf(Voided::class);
     }
 
     /**

--- a/src/Service/DocumentRequestInterface.php
+++ b/src/Service/DocumentRequestInterface.php
@@ -18,45 +18,43 @@ use Symfony\Component\HttpFoundation\Response;
 interface DocumentRequestInterface
 {
     /**
-     * Set document to process.
-     *
-     * @param string $class
-     */
-    public function setDocumentType(string $class);
-
-    /**
      * Get Result.
      *
+     * @param string $class
      * @return Response
      */
-    public function send(): Response;
+    public function send(string $class): Response;
 
     /**
      * Get Xml.
      *
+     * @param string $class
      * @return Response
      */
-    public function xml(): Response;
+    public function xml(string $class): Response;
 
     /**
      * Get Pdf.
      *
+     * @param string $class
      * @return Response
      */
-    public function pdf(): Response;
+    public function pdf(string $class): Response;
 
     /**
      * Get Configured See.
      *
+     * @param string $class
      * @param string $ruc
      * @return See
      */
-    public function getSee(string $ruc): See;
+    public function getSee(string $class, string $ruc): See;
 
     /**
      * Get parsed document.
      *
+     * @param string $class
      * @return DocumentInterface
      */
-    public function getDocument(): DocumentInterface;
+    public function getDocument(string $class): DocumentInterface;
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where the `DocumentRequest` service shared state across requests, causing cross-request contamination and unpredictable errors when using multiple endpoints in sequence. The service is now stateless, and all controllers have been updated to pass the document class explicitly to each method.

## Key Changes

- Removed per-request state from `DocumentRequest` (no more `$className` or `setDocumentType()`)
- `send`, `xml`, and `pdf` now require the document class as an argument
- All controllers updated to pass the document class explicitly

## Motivation

Previously, using endpoints like summary or voided would affect subsequent requests (e.g., invoice) due to shared state in a singleton service. This PR ensures each request is handled independently, fixing these bugs.

## How I Found the Issue

I followed the docker instructions (built the image locally on Windows) and used the [postman collection](https://www.postman.com/greenter/lycet/collection/yvsxedr/lycet-examples?action=share&source=copy-link&creator=46102969)  and encountered errors after using summary/voided endpoints.

When using the invoice endpoint after the voided, this is the log I got:

```bash
{"message":"Matched route \"app_v1_invoice_send\".","context":{"route":"app_v1_invoice_send","route_parameters":{"_route":"app_v1_invoice_send","_controller":"App\\Controller\\v1\\InvoiceController::send"},"request_uri":"http://localhost:8000/api/v1/invoice/send?token=123456","method":"POST"},"level":200,"level_name":"INFO","channel":"request","datetime":"2025-07-12T10:06:58.559315-05:00","extra":{}}

{"message":"Uncaught PHP Exception Twig\\Error\\RuntimeError: \"An exception has been thrown during the rendering of a template (\"Greenter\\Model\\Voided\\Voided::getDateWithTimezone(): Argument #1 ($date) must be of type DateTimeInterface, null given, called in /var/www/html/vendor/greenter/core/src/Core/Model/Voided/Voided.php on line 161\").\" at /var/www/html/vendor/greenter/xml/src/Xml/Templates/voided.xml.twig line 11","context":{"exception":{"class":"Twig\\Error\\RuntimeError","message":"An exception has been thrown during the rendering of a template (\"Greenter\\Model\\Voided\\Voided::getDateWithTimezone(): Argument #1 ($date) must be of type DateTimeInterface, null given, called in /var/www/html/vendor/greenter/core/src/Core/Model/Voided/Voided.php on line 161\").","code":0,"file":"/var/www/html/vendor/greenter/xml/src/Xml/Templates/voided.xml.twig:11","previous":{"class":"TypeError","message":"Greenter\\Model\\Voided\\Voided::getDateWithTimezone(): Argument #1 ($date) must be of type DateTimeInterface, null given, called in /var/www/html/vendor/greenter/core/src/Core/Model/Voided/Voided.php on line 161","code":0,"file":"/var/www/html/vendor/greenter/core/src/Core/Model/TimezonePeTrait.php:14"}}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2025-07-12T10:06:58.569095-05:00","extra":{}}.
```

When using the invoice endpoints after using the summary, this is the log I got:

```bash
{"message":"Matched route \"app_v1_invoice_send\".","context":{"route":"app_v1_invoice_send","route_parameters":{"_route":"app_v1_invoice_send","_controller":"App\\Controller\\v1\\InvoiceController::send"},"request_uri":"http://localhost:8000/api/v1/invoice/send?token=123456","method":"POST"},"level":200,"level_name":"INFO","channel":"request","datetime":"2025-07-12T10:17:37.513146-05:00","extra":{}}

{"message":"Uncaught PHP Exception Twig\\Error\\RuntimeError: \"An exception has been thrown during the rendering of a template (\"Greenter\\Model\\Summary\\Summary::getDateWithTimezone(): Argument #1 ($date) must be of type DateTimeInterface, null given, called in /var/www/html/vendor/greenter/core/src/Core/Model/Summary/Summary.php on line 186\").\" at /var/www/html/vendor/greenter/xml/src/Xml/Templates/summary.xml.twig line 11","context":{"exception":{"class":"Twig\\Error\\RuntimeError","message":"An exception has been thrown during the rendering of a template (\"Greenter\\Model\\Summary\\Summary::getDateWithTimezone(): Argument #1 ($date) must be of type DateTimeInterface, null given, called in /var/www/html/vendor/greenter/core/src/Core/Model/Summary/Summary.php on line 186\").","code":0,"file":"/var/www/html/vendor/greenter/xml/src/Xml/Templates/summary.xml.twig:11","previous":{"class":"TypeError","message":"Greenter\\Model\\Summary\\Summary::getDateWithTimezone(): Argument #1 ($date) must be of type DateTimeInterface, null given, called in /var/www/html/vendor/greenter/core/src/Core/Model/Summary/Summary.php on line 186","code":0,"file":"/var/www/html/vendor/greenter/core/src/Core/Model/TimezonePeTrait.php:14"}}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2025-07-12T10:17:37.520516-05:00","extra":{}}
```

## Benefits

- Fixes cross-request bugs
- Improves thread safety and code clarity
- Aligns with Symfony best practices

## Testing

- All endpoints tested in sequence; no regressions found.

## Additional Notes

- This PR does **not** change the external API or request/response formats.
