### PR TITLE
docs: add missing /invoice/status endpoint to swagger

### DIFF
--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -94,6 +94,45 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ValidationResponse"
+  /invoice/status:
+    get:
+      tags:
+        - invoice
+      summary: Obtiene el estado del CDR de una Factura o Boleta
+      description: Retorna el CDR desde SUNAT
+      operationId: getInvoiceStatus
+      parameters:
+        - name: tipo
+          in: query
+          description: Tipo de comprobante (Ej. 01, 03)
+          required: true
+          schema:
+            type: string
+        - name: serie
+          in: query
+          description: Serie del comprobante (Ej. F001)
+          required: true
+          schema:
+            type: string
+        - name: numero
+          in: query
+          description: Número correlativo del comprobante
+          required: true
+          schema:
+            type: string
+        - name: ruc
+          in: query
+          description: RUC de empresa (Múltiples Empresas)
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Operacion exitosa
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusResult"
   /note/send:
     post:
       tags:


### PR DESCRIPTION
### Description
The `/invoice/status` endpoint was fully implemented and functional in the `InvoiceController.php` (lines 80-116), but its definition was completely missing from the `public/swagger.yaml` file. 

### Why is this important?
This omission prevents code-generator tools (like Swagger Editor / OpenAPI Generators) from building the `GetInvoiceStatus` method in the generated SDKs for consumers (C#, Java, TypeScript, etc), forcing developers to implement the API call manually.

### Changes made
- Added the `/invoice/status` `GET` endpoint definition to `swagger.yaml`.
- Added the exact `tipo`, `serie`, `numero` (required) and `ruc` (optional) query parameters to match the controller's exact behavior.
- Pointed the response schema to the existing `$ref: "#/components/schemas/StatusResult"`.

This small documentation fix restores full SDK generation compatibility for electronic invoice status checks!
