### PR TITLE
feat: add company configuration endpoints and update docs page

### DIFF
--- a/public/swagger.yaml
+++ b/public/swagger.yaml
@@ -719,6 +719,134 @@ paths:
       responses:
         "200":
           description: Operacion exitosa
+  /configuration/company/{ruc}:
+    put:
+      tags:
+        - configuration
+      summary: Registrar o actualizar empresa
+      description: Registra o actualiza la configuración de una empresa para facturación electrónica.
+      operationId: saveCompanyConfiguration
+      parameters:
+        - name: ruc
+          in: path
+          description: RUC de la empresa
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          description: Token de autenticación
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - SOL_USER
+                - SOL_PASS
+                - certificate
+                - FE_URL
+              properties:
+                SOL_USER:
+                  type: string
+                  example: 20000000001MODDATOS
+                SOL_PASS:
+                  type: string
+                  example: moddatos
+                certificate:
+                  type: string
+                  description: Certificado .pem codificado en base64
+                  example: "<certificado .pem en base64>"
+                FE_URL:
+                  type: string
+                  example: https://e-factura.sunat.gob.pe/ol-ti-itcpfegem/billService
+      responses:
+        "200":
+          description: Empresa registrada o actualizada correctamente
+    delete:
+      tags:
+        - configuration
+      summary: Eliminar empresa
+      description: Elimina la configuración registrada de una empresa.
+      operationId: deleteCompanyConfiguration
+      parameters:
+        - name: ruc
+          in: path
+          description: RUC de la empresa
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          description: Token de autenticación
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Empresa eliminada correctamente
+  /configuration/company/{ruc}/logo:
+    put:
+      tags:
+        - configuration
+      summary: Subir logo de empresa
+      description: Sube o actualiza el logo de una empresa en base64.
+      operationId: saveCompanyLogo
+      parameters:
+        - name: ruc
+          in: path
+          description: RUC de la empresa
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          description: Token de autenticación
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - logo
+              properties:
+                logo:
+                  type: string
+                  description: Logo codificado en base64
+                  example: "<logo en base64>"
+      responses:
+        "200":
+          description: Logo registrado o actualizado correctamente
+    delete:
+      tags:
+        - configuration
+      summary: Eliminar logo de empresa
+      description: Elimina el logo registrado de una empresa.
+      operationId: deleteCompanyLogo
+      parameters:
+        - name: ruc
+          in: path
+          description: RUC de la empresa
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          description: Token de autenticación
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Logo eliminado correctamente
 servers:
   - url: http://lycet.api/api/v1
   - url: https://lycet.api/api/v1

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -24,13 +24,49 @@ class HomeController
      */
     public function index(Request $request): Response
     {
-        $pathDocs = $request->getUriForPath('/swagger');
-        $content = $this->getWithReplace(
-            __DIR__.'/../../views/welcome.html',
-            'lycet.api',
-            $pathDocs);
+        $pathDocs = $request->getUriForPath('/docs');
 
-        return new Response($content, 200, ['Content-Type', 'text/html']);
+        $content = $this->getWithReplace(
+            __DIR__ . '/../../views/welcome.html',
+            'lycet.api',
+            $pathDocs
+        );
+
+        return new Response($content, 200, ['Content-Type' => 'text/html']);
+    }
+
+    /**
+     * @Route("/docs")
+     * @param Request $request
+     * @return Response
+     */
+    public function docs(Request $request): Response
+    {
+        $swaggerUrl = $request->getUriForPath('/swagger');
+
+        $content = <<<HTML
+            <!doctype html>
+            <html lang="es">
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <title>Lycet API Reference</title>
+            </head>
+            <body>
+                <div id="app"></div>
+
+                <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+                <script>
+                    Scalar.createApiReference('#app', {
+                        url: '{$swaggerUrl}',
+                        theme: 'default'
+                    });
+                </script>
+            </body>
+            </html>
+        HTML;
+
+        return new Response($content, 200, ['Content-Type' => 'text/html']);
     }
 
     /**
@@ -40,11 +76,13 @@ class HomeController
      */
     public function swagger(Request $request): Response
     {
-        $rootUrl = $request->getHttpHost().$request->getBasePath();
+        $rootUrl = $request->getHttpHost() . $request->getBasePath();
+
         $content = $this->getWithReplace(
-            __DIR__.'/../../public/swagger.yaml',
+            __DIR__ . '/../../public/swagger.yaml',
             'lycet.api',
-            $rootUrl);
+            $rootUrl
+        );
 
         return new Response($content, 200, ['Content-Type' => 'text/yaml']);
     }

--- a/views/welcome.html
+++ b/views/welcome.html
@@ -62,7 +62,7 @@
             Lycet
         </div>
         <div class="links">
-            <a href="http://petstore.swagger.io/?url=lycet.api">API Reference</a>
+            <a href="/docs">API Reference</a>
             <a href="https://github.com/giansalex/lycet">GitHub</a>
         </div>
     </div>


### PR DESCRIPTION
Se documentan los endpoints de configuración de empresas y gestión de logos que ya se encontraban disponibles en la API, permitiendo su visualización y consumo desde la especificación OpenAPI. Adicionalmente, se reemplaza la página de documentación anterior por una nueva interfaz basada en Scalar, ofreciendo una experiencia más moderna y amigable para desarrolladores e integradores.